### PR TITLE
Optimized hashmap.hpp

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ A header-only library for high-performance, low-latency systems. Built for learn
 - Treiber Stack (lock-free LIFO)
 - Object Pool (lock-free with RAII)
 - Ring Buffer (Vyukov MPMC)
-- HashMap (lock-free, 7.5x faster finds)
+- HashMap (fixed-capacity concurrent map; benchmark results are workload-specific)
 - Atomic Counter (wait-free)
 - RCU (Read-Copy-Update)
 - Google Benchmark integration
@@ -30,7 +30,7 @@ A header-only library for high-performance, low-latency systems. Built for learn
 - Bounded MPMC ring buffer
 - Object pool
 - MPMC queue and Treiber stack with experimental hazard-pointer reclamation
-- Fixed-capacity hashmap, atomic counter, and experimental RCU variants
+- Fixed-capacity concurrent hashmap, atomic counter, and experimental RCU variants
 
 The MPMC queue, stack, hashmap, object pool, ring buffer, and RCU variants are
 provisional until the correctness and lifecycle work recorded in

--- a/include/lockfree/hashmap.hpp
+++ b/include/lockfree/hashmap.hpp
@@ -1,132 +1,217 @@
 #pragma once
+
 #include <atomic>
-#include <optional>
-#include <vector>
+#include <cstddef>
 #include <functional>
 #include <memory>
+#include <optional>
+#include <utility>
+
 #include "utils.hpp"
 
 namespace lockfree {
 
 /**
- * Lock-Free HashMap
- * 
- * Fixed-size hash map with linear probing and CAS updates.
- * Thread-safe for multiple producers/consumers.
+ * Fixed-capacity concurrent hash map.
+ *
+ * Entries are immutable and are published with the C++ atomic shared_ptr
+ * operations.  A null slot is empty; m_tombstone is a deleted slot.  Keeping
+ * tombstones is required by open addressing: a lookup may only stop at a null
+ * slot, otherwise deletion could hide a colliding key farther down the probe
+ * sequence.
+ *
+ * This class is thread-safe for insert, find, erase, and contains.  It is not
+ * lock-free: atomic shared_ptr operations may use an internal lock.  In return
+ * it safely supports non-trivial Key and Value types, including std::string.
+ * The map must outlive all operations on it.
  */
-template<typename Key, typename Value, size_t Capacity = 1048576>
+template<typename Key, typename Value, std::size_t Capacity = 1048576>
 class HashMap {
-    static_assert((Capacity & (Capacity - 1)) == 0, "Capacity must be power of 2");
-    
+    static_assert(Capacity > 0 && (Capacity & (Capacity - 1)) == 0,
+                  "Capacity must be a non-zero power of two");
+
+private:
+    struct Entry {
+        Entry() = default;
+
+        template<typename K, typename V>
+        Entry(K&& entry_key, V&& entry_value)
+            : key(std::forward<K>(entry_key)),
+              value(std::forward<V>(entry_value)) {}
+
+        std::optional<Key> key;
+        std::optional<Value> value;
+    };
+
+    using entry_ptr = std::shared_ptr<const Entry>;
+
+    // Avoid inflating every slot to a full cache line.
+    static constexpr std::size_t slots_per_group = 8;
+    static constexpr std::size_t group_count =
+        (Capacity + slots_per_group - 1) / slots_per_group;
+
+    struct alignas(CACHE_LINE_SIZE) SlotGroup {
+        entry_ptr slots[slots_per_group];
+    };
+
 public:
-    HashMap() : m_size(0) {
-        // Initialize all slots as empty
-        for (size_t i = 0; i < Capacity; i++) {
-            m_occupied[i].store(false, std::memory_order_relaxed);
-        }
-    }
-    
-    // Disable copy
+    HashMap()
+        : m_slots(std::make_unique<SlotGroup[]>(group_count)),
+          m_tombstone(std::make_shared<Entry>()),
+          m_size(0) {}
+
     HashMap(const HashMap&) = delete;
     HashMap& operator=(const HashMap&) = delete;
-    
+
     bool insert(const Key& key, const Value& value) {
-        size_t idx = hash(key);
-        size_t start = idx;
-        
-        while (true) {
-            bool expected = false;
-            
-            // Try to claim this slot if empty
-            if (m_occupied[idx].compare_exchange_weak(expected, true,
-                std::memory_order_acquire, std::memory_order_relaxed)) {
-                m_keys[idx] = key;
-                m_values[idx].store(value, std::memory_order_release);
+        const auto desired = std::make_shared<Entry>(key, value);
+
+        // Restarting after a failed CAS ensures an update never overwrites a newer value and that concurrent same-key inserts cannot duplicate it.
+        for (;;) {
+            std::optional<std::size_t> first_tombstone;
+            std::size_t index = hash(key);
+            std::size_t step = 1;
+            bool retry = false;
+
+            for (std::size_t probes = 0; probes < Capacity; ++probes) {
+                entry_ptr observed = load_slot(index);
+
+                if (!observed) {
+                    const std::size_t target = first_tombstone.value_or(index);
+                    entry_ptr expected = first_tombstone ? m_tombstone : entry_ptr{};
+                    if (compare_exchange_slot(target, expected, desired)) {
+                        m_size.fetch_add(1, std::memory_order_relaxed);
+                        return true;
+                    }
+                    retry = true;
+                    break;
+                }
+
+                if (observed == m_tombstone) {
+                    if (!first_tombstone) {
+                        first_tombstone = index;
+                    }
+                } else if (*observed->key == key) {
+                    entry_ptr expected = std::move(observed);
+                    if (compare_exchange_slot(index, expected, desired)) {
+                        return true;
+                    }
+                    retry = true;
+                    break;
+                }
+
+                index = next_index(index, step++);
+            }
+
+            if (retry) {
+                continue;
+            }
+            if (!first_tombstone) {
+                return false;
+            }
+
+            entry_ptr expected = m_tombstone;
+            if (compare_exchange_slot(*first_tombstone, expected, desired)) {
                 m_size.fetch_add(1, std::memory_order_relaxed);
                 return true;
             }
-            
-            // Slot already occupied, check if it's our key
-            if (m_keys[idx] == key) {
-                m_values[idx].store(value, std::memory_order_release);
-                return true;
-            }
-            
-            // Move to next slot
-            idx = (idx + 1) & (Capacity - 1);
-            if (idx == start) {
-                return false;  // Table full
-            }
         }
     }
-    
+
     std::optional<Value> find(const Key& key) const {
-        size_t idx = hash(key);
-        size_t start = idx;
-        
-        while (true) {
-            if (!m_occupied[idx].load(std::memory_order_acquire)) {
+        std::size_t index = hash(key);
+        std::size_t step = 1;
+
+        for (std::size_t probes = 0; probes < Capacity; ++probes) {
+            const entry_ptr observed = load_slot(index);
+            if (!observed) {
                 return std::nullopt;
             }
-            
-            if (m_keys[idx] == key) {
-                return m_values[idx].load(std::memory_order_acquire);
+            if (observed != m_tombstone && *observed->key == key) {
+                return *observed->value;
             }
-            
-            idx = (idx + 1) & (Capacity - 1);
-            if (idx == start) {
-                return std::nullopt;
-            }
+            index = next_index(index, step++);
         }
+        return std::nullopt;
     }
-    
+
     bool erase(const Key& key) {
-        size_t idx = hash(key);
-        size_t start = idx;
-        
-        while (true) {
-            if (!m_occupied[idx].load(std::memory_order_acquire)) {
-                return false;
+        for (;;) {
+            std::size_t index = hash(key);
+            std::size_t step = 1;
+
+            for (std::size_t probes = 0; probes < Capacity; ++probes) {
+                entry_ptr observed = load_slot(index);
+                if (!observed) {
+                    return false;
+                }
+                if (observed != m_tombstone && *observed->key == key) {
+                    entry_ptr expected = std::move(observed);
+                    if (compare_exchange_slot(index, expected, m_tombstone)) {
+                        m_size.fetch_sub(1, std::memory_order_relaxed);
+                        return true;
+                    }
+                    break;
+                }
+                index = next_index(index, step++);
             }
-            
-            if (m_keys[idx] == key) {
-                m_occupied[idx].store(false, std::memory_order_release);
-                m_size.fetch_sub(1, std::memory_order_relaxed);
-                return true;
-            }
-            
-            idx = (idx + 1) & (Capacity - 1);
-            if (idx == start) {
+
+            // We reached a real empty slot or lost a race.  Retrying handles
+            // the latter; a complete probe without a matching key is absent.
+            if (step > Capacity) {
                 return false;
             }
         }
     }
-    
+
     bool contains(const Key& key) const {
         return find(key).has_value();
     }
-    
-    size_t size() const {
+
+    // Concurrent operations may make this a transient snapshot.
+    std::size_t size() const noexcept {
         return m_size.load(std::memory_order_relaxed);
     }
-    
-    bool empty() const {
+
+    bool empty() const noexcept {
         return size() == 0;
     }
-    
-    constexpr size_t capacity() const {
+
+    constexpr std::size_t capacity() const noexcept {
         return Capacity;
     }
-    
+
 private:
-    size_t hash(const Key& key) const {
+    std::size_t hash(const Key& key) const {
         return std::hash<Key>{}(key) & (Capacity - 1);
     }
-    
-    alignas(CACHE_LINE_SIZE) std::atomic<bool> m_occupied[Capacity];
-    Key m_keys[Capacity];
-    alignas(CACHE_LINE_SIZE) std::atomic<Value> m_values[Capacity];
-    std::atomic<size_t> m_size;
+
+    static std::size_t next_index(std::size_t index, std::size_t step) noexcept {
+        return (index + step) & (Capacity - 1);
+    }
+
+    entry_ptr& slot(std::size_t index) noexcept {
+        return m_slots[index / slots_per_group].slots[index % slots_per_group];
+    }
+
+    const entry_ptr& slot(std::size_t index) const noexcept {
+        return m_slots[index / slots_per_group].slots[index % slots_per_group];
+    }
+
+    entry_ptr load_slot(std::size_t index) const {
+        return std::atomic_load_explicit(&slot(index), std::memory_order_acquire);
+    }
+
+    bool compare_exchange_slot(std::size_t index, entry_ptr& expected,
+                               const entry_ptr& desired) {
+        return std::atomic_compare_exchange_strong_explicit(
+            &slot(index), &expected, desired,
+            std::memory_order_release, std::memory_order_acquire);
+    }
+
+    std::unique_ptr<SlotGroup[]> m_slots;
+    const entry_ptr m_tombstone;
+    alignas(CACHE_LINE_SIZE) std::atomic<std::size_t> m_size;
 };
 
-}
+} // namespace lockfree

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -722,6 +722,35 @@ TEST_CASE(test_hashmap_erase_reinsert) {
     return true;
 }
 
+TEST_CASE(test_hashmap_tombstone_preserves_probe_chain) {
+    // 0, 8, and 16 have the same initial bucket.  Removing the first key must
+    // not make the later colliding keys invisible.
+    lockfree::HashMap<int, int, 8> map;
+
+    ASSERT(map.insert(0, 10));
+    ASSERT(map.insert(8, 20));
+    ASSERT(map.insert(16, 30));
+    ASSERT(map.erase(0));
+
+    auto value = map.find(8);
+    ASSERT(value.has_value());
+    ASSERT_EQ(*value, 20);
+    value = map.find(16);
+    ASSERT(value.has_value());
+    ASSERT_EQ(*value, 30);
+
+    // The tombstone is reusable, but insertion must first search past it so
+    // that an existing key is updated rather than duplicated.
+    ASSERT(map.insert(8, 200));
+    ASSERT_EQ(map.size(), 2);
+    ASSERT_EQ(map.find(8).value(), 200);
+    ASSERT(map.insert(24, 40));
+    ASSERT_EQ(map.size(), 3);
+    ASSERT_EQ(map.find(24).value(), 40);
+
+    return true;
+}
+
 TEST_CASE(test_hashmap_update_value) {
     lockfree::HashMap<int, int, 1024> map;
     
@@ -829,7 +858,9 @@ TEST_CASE(test_hashmap_concurrent_insert_find) {
     const int NUM_THREADS = 4;
     const int OPS_PER_THREAD = 2500;
     std::atomic<bool> start{false};
-    std::atomic<int> errors{0};
+    std::atomic<int> insert_failures{0};
+    std::atomic<int> missing_values{0};
+    std::atomic<int> incorrect_values{0};
     
     std::vector<std::thread> threads;
     
@@ -839,12 +870,17 @@ TEST_CASE(test_hashmap_concurrent_insert_find) {
             
             for (int i = 0; i < OPS_PER_THREAD; i++) {
                 int key = t * OPS_PER_THREAD + i;
-                map.insert(key, key * 10);
+                if (!map.insert(key, key * 10)) {
+                    insert_failures.fetch_add(1, std::memory_order_relaxed);
+                    continue;
+                }
                 
                 // Verify immediately
                 auto val = map.find(key);
-                if (!val.has_value() || *val != key * 10) {
-                    errors++;
+                if (!val.has_value()) {
+                    missing_values.fetch_add(1, std::memory_order_relaxed);
+                } else if (*val != key * 10) {
+                    incorrect_values.fetch_add(1, std::memory_order_relaxed);
                 }
             }
         });
@@ -853,9 +889,45 @@ TEST_CASE(test_hashmap_concurrent_insert_find) {
     start = true;
     for (auto& th : threads) th.join();
     
-    ASSERT_EQ(errors, 0);
+    ASSERT_EQ(insert_failures.load(std::memory_order_relaxed), 0);
+    ASSERT_EQ(missing_values.load(std::memory_order_relaxed), 0);
+    ASSERT_EQ(incorrect_values.load(std::memory_order_relaxed), 0);
     ASSERT_EQ(map.size(), NUM_THREADS * OPS_PER_THREAD);
     
+    return true;
+}
+
+TEST_CASE(test_hashmap_concurrent_same_key_insert) {
+    lockfree::HashMap<int, int, 16> map;
+    constexpr int NUM_THREADS = 8;
+    std::atomic<bool> start{false};
+    std::atomic<int> insert_failures{0};
+    std::vector<std::thread> threads;
+
+    for (int thread_id = 0; thread_id < NUM_THREADS; ++thread_id) {
+        threads.emplace_back([&, thread_id]() {
+            while (!start.load(std::memory_order_acquire)) {
+                std::this_thread::yield();
+            }
+            if (!map.insert(7, thread_id)) {
+                insert_failures.fetch_add(1, std::memory_order_relaxed);
+            }
+        });
+    }
+
+    start.store(true, std::memory_order_release);
+    for (auto& thread : threads) {
+        thread.join();
+    }
+
+    // Every writer targets the same key.  The map must update one entry, not
+    // publish several copies in the collision sequence.
+    ASSERT_EQ(insert_failures.load(std::memory_order_relaxed), 0);
+    ASSERT_EQ(map.size(), 1);
+    const auto value = map.find(7);
+    ASSERT(value.has_value());
+    ASSERT(*value >= 0 && *value < NUM_THREADS);
+
     return true;
 }
 


### PR DESCRIPTION
Changes made:

- Added empty / tombstone / immutable entry slot semantics
- Replaced unsafe key/value publication with immutable entries, release-CAS publication, and acquire reads
- Added safe lifetime reclamation through atomic shared_ptr operations so no hazard pointers needed
- Replaced linear probing with full-cycle quadratic probing
- Moved table storage to the heap and grouped slots on cache-line boundaries; isolated the size counter
- Fixed duplicate same-key insertion and concurrent erase/update races
- Rejects zero capacity